### PR TITLE
Update sample.cfg

### DIFF
--- a/Configs/sample.cfg
+++ b/Configs/sample.cfg
@@ -1,5 +1,5 @@
 [config]
-baseurl = "http://en.wikipedia.org/w/api.php"
+baseurl = "https://en.wikipedia.org/w/api.php"
 username = "Example"
 password = "1234567890"
 maxlag = "0"


### PR DESCRIPTION
Changing example baseurl protocol to show HTTPS support.

(Does Wikipedia API still work via uncrypter HTTP?)
