### PR TITLE
Introduce type hinting for Wiki class

### DIFF
--- a/GenFunctions.php
+++ b/GenFunctions.php
@@ -111,7 +111,7 @@ function rglob( $pattern = '*', $flags = 0, $path = '' ) {
  * @param string $optout Text to search for in the optout= parameter. (default: null)
  * @return bool True on match of an appropriate nobots template
  */
-function checkExclusion( $wiki, $text = '', $username = null, $optout = null ) {
+function checkExclusion( Wiki $wiki, $text = '', $username = null, $optout = null ) {
 	if( !$wiki->get_nobots() ) return false;
 
 	if( in_string( "{{nobots}}", $text ) ) return true;

--- a/Includes/Image.php
+++ b/Includes/Image.php
@@ -172,7 +172,7 @@ class Image {
 	 * @param string $title
 	 * @return void
 	 */
-	function __construct( &$wikiClass, $title = null ) {
+	function __construct( Wiki &$wikiClass, $title = null ) {
 
 		$this->wiki = & $wikiClass;
 

--- a/Includes/Page.php
+++ b/Includes/Page.php
@@ -331,7 +331,7 @@ class Page {
 	 * @param string $timestamp Set the start of a program or start reference to avoid edit conflicts.
 	 * @return void
 	 */
-	function __construct( $wikiClass, $title = null, $pageid = null, $followRedir = true, $normalize = true, $timestamp = null ) {
+	function __construct( Wiki $wikiClass, $title = null, $pageid = null, $followRedir = true, $normalize = true, $timestamp = null ) {
 		$this->wiki = $wikiClass;
 
 		if( is_null( $title ) && is_null( $pageid ) ) {

--- a/Includes/PeachyAWBFunctions.php
+++ b/Includes/PeachyAWBFunctions.php
@@ -100,7 +100,7 @@ class PeachyAWBFunctions {
 
 	public static $typo_list = array();
 
-	public static function fixVars( $wiki ) {
+	public static function fixVars( Wiki $wiki ) {
 		$interwiki = $wiki->siteinfo( array( 'interwikimap' ) );
 		self::$interwiki_map = $interwiki['query']['interwikimap'];
 	}

--- a/Includes/User.php
+++ b/Includes/User.php
@@ -118,7 +118,7 @@ class User {
 	 * @param Wiki $wikiClass
 	 * @return null|false
 	 */
-	function __construct( &$wikiClass, $username ) {
+	function __construct( Wiki &$wikiClass, $username ) {
 
 		$this->wiki = & $wikiClass;
 

--- a/Plugins/AbuseFilter.php
+++ b/Plugins/AbuseFilter.php
@@ -34,7 +34,7 @@ class AbuseFilter {
 	 * @param Wiki &$wikiClass The Wiki class object
 	 * @return void
 	 */
-	function __construct( &$wikiClass ) {
+	function __construct( Wiki &$wikiClass ) {
 		$this->wiki = $wikiClass;
 
 		if( !array_key_exists( 'Abuse Filter', $wikiClass->get_extensions() ) ) {

--- a/Plugins/CheckUser.php
+++ b/Plugins/CheckUser.php
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class CheckUser {
 
-	function __construct( &$wikiclass = null ) {
+	function __construct( Wiki &$wikiclass = null ) {
 
 		$extensions = $wikiClass->get_extensions();
 		if( !array_key_exists( 'CheckUser', $extensions ) ) {

--- a/Plugins/CodeReview.php
+++ b/Plugins/CodeReview.php
@@ -23,7 +23,7 @@ class CodeReview {
 
 	private $repo;
 
-	function __construct( &$wikiClass, $repo ) {
+	function __construct( Wiki &$wikiClass, $repo ) {
 		$this->wiki = $wikiClass;
 		$this->repo = $repo;
 

--- a/Plugins/FlaggedRevs.php
+++ b/Plugins/FlaggedRevs.php
@@ -21,7 +21,7 @@ class FlaggedRevs {
 
 	private $wiki;
 
-	function __construct( &$wikiClass ) {
+	function __construct( Wiki &$wikiClass ) {
 
 		if( !array_key_exists( 'FlaggedRevs', $wikiClass->get_extensions() ) ) {
 			throw new DependencyError( "FlaggedRevs", "http://www.mediawiki.org/wiki/Extension:FlaggedRevs" );

--- a/Plugins/GlobalBlocking.php
+++ b/Plugins/GlobalBlocking.php
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class GlobalBlocking {
 
-	public static function load( &$wikiClass ) {
+	public static function load( Wiki &$wikiClass ) {
 
 		if( !array_key_exists( 'GlobalBlocking', $wikiClass->get_extensions() ) ) {
 			throw new DependencyError( "GlobalBlocking", "http://www.mediawiki.org/wiki/Extension:GlobalBlocking" );

--- a/Plugins/GlobalUserInfo.php
+++ b/Plugins/GlobalUserInfo.php
@@ -91,7 +91,7 @@ class GlobalUserInfo {
 	 * @param mixed $username Username
 	 * @return void
 	 */
-	function __construct( &$wikiClass, $username ) {
+	function __construct( Wiki &$wikiClass, $username ) {
 
 		if( !array_key_exists( 'Central Auth', $wikiClass->get_extensions() ) ) {
 			throw new DependencyError( "CentralAuth", "http://www.mediawiki.org/wiki/Extension:CentralAuth" );

--- a/Plugins/RFA.php
+++ b/Plugins/RFA.php
@@ -235,7 +235,7 @@ class RFA {
 	/*
  	* Analyzes an RFA. Returns TRUE on success, FALSE on failure
  	*/
-	function __construct( $wiki, $page, $rawwikitext = null ) {
+	function __construct( Wiki $wiki, $page, $rawwikitext = null ) {
 		if( is_null( $rawwikitext ) ) $rawwikitext = $wiki->initPage( $page )->get_text();
 
 		$split = preg_split(

--- a/Plugins/RPED.php
+++ b/Plugins/RPED.php
@@ -43,7 +43,7 @@ class RPED {
 	 * @param Wiki &$wikiClass The Wiki class object
 	 * @return void
 	 */
-	function __construct( &$wikiClass ) {
+	function __construct( Wiki &$wikiClass ) {
 		$this->wiki = $wikiClass;
 		$defaultMaxURLLength = 2000;
 		return;

--- a/Plugins/SiteMatrix.php
+++ b/Plugins/SiteMatrix.php
@@ -27,7 +27,7 @@ class SiteMatrix {
 	 * @param Wiki &$wikiClass The Wiki class object
 	 * @return array List of all wikis
 	 */
-	public static function load( &$wikiClass ) {
+	public static function load( Wiki &$wikiClass ) {
 
 		if( !array_key_exists( 'SiteMatrix', $wikiClass->get_extensions() ) ) {
 			throw new DependencyError( "SiteMatrix" );


### PR DESCRIPTION
The Wiki class gets passed around a lot. Type hinting is helpful
and is cost-free when there are no back-compat issues.

See also
https://www.mediawiki.org/wiki/Architecture_guidelines#Type_Hinting
