### PR TITLE
Update Page.php

### DIFF
--- a/Includes/Page.php
+++ b/Includes/Page.php
@@ -1169,7 +1169,7 @@ class Page {
 		pecho( "Making edit to {$this->title}...\n\n", PECHO_NORMAL );
 
 		$editarray = array(
-			'title'         => $this->title,
+			'pageid'         => $this->pageid,
 			'action'        => 'edit',
 			'token'         => $tokens['edit'],
 			'basetimestamp' => $this->lastedit,


### PR DESCRIPTION
in some cases, editing a page using it's name will produce exceptions and errors (for example : when the title is '@'). 

Using the 'pageid' in stead of the 'title' give an universal solution for any language.