### PR TITLE
Revert one component of 5141fb74 (use of empty())

### DIFF
--- a/Includes/User.php
+++ b/Includes/User.php
@@ -139,7 +139,7 @@ class User {
 			)
 		);
 
-		if (!empty($uiRes)) {
+		if ( !$uiRes ) {
 			$this->username = $pgUsername;
 			$this->exists = false;
 		} else {


### PR DESCRIPTION
This yields $exists = false when the user does in fact exist.

Probably just a logic error (i.e. should be exists() not !exists()) but I'm not clear why using empty() is desirable anyway (0 is not a valid return).