### PR TITLE
readme: Update Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ If you have feature requests please file a bug.
 
 ###### Badges
 
-* Status: [![Build Status](https://travis-ci.org/MW-Peachy/Peachy.png)](https://travis-ci.org/MW-Peachy/Peachy)
+* Status: [![Build Status](https://travis-ci.org/MW-Peachy/Peachy.svg?branch=master)](https://travis-ci.org/MW-Peachy/Peachy)
 * Coverage: [![Code Coverage](https://scrutinizer-ci.com/g/MW-Peachy/Peachy/badges/coverage.png?s=c4f43d2284ed1fe068b692b9d7778f940912f2ee)](https://scrutinizer-ci.com/g/MW-Peachy/Peachy/)
 * Quality: [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/MW-Peachy/Peachy/badges/quality-score.png?s=16084244d02ed6ee537ab1dbd1c7bc4310a30049)](https://scrutinizer-ci.com/g/MW-Peachy/Peachy/)


### PR DESCRIPTION
Currently this was only one of three badges that wasn't high resolution.

The other two automatically serve SVG already (even though it's a PNG url), but Travis doesn't do that.

<img width="312" alt="screen shot" src="https://cloud.githubusercontent.com/assets/156867/14369226/235d18f8-fd1b-11e5-85bb-7458196ace53.png">
