### PR TITLE
Remove use of cURL CLOSEPOLICY constants

### DIFF
--- a/HTTP.php
+++ b/HTTP.php
@@ -110,7 +110,6 @@ class HTTP {
 		$this->setCookieJar( $this->cookie_jar );
 
 		curl_setopt( $this->curl_instance, CURLOPT_MAXCONNECTS, 100 );
-		curl_setopt( $this->curl_instance, CURLOPT_CLOSEPOLICY, CURLCLOSEPOLICY_LEAST_RECENTLY_USED );
 		curl_setopt( $this->curl_instance, CURLOPT_MAXREDIRS, 10 );
 		$this->setCurlHeaders();
 		curl_setopt( $this->curl_instance, CURLOPT_ENCODING, 'gzip' );


### PR DESCRIPTION
They were noneffective and have been removed in PHP 5.6

Fixes "undefined constant, assumed string" notices, and warnings with `curl_setopt()` subsequently.

<br>References:
* https://bugs.php.net/bug.php?id=68147
* http://php.net/manual/en/function.curl-setopt.php