### PR TITLE
Restore Image::imageinfo's history capability.

### DIFF
--- a/Includes/Image.php
+++ b/Includes/Image.php
@@ -176,6 +176,7 @@ class Image {
 		$ii = $this->imageinfo();
 
 		if( is_array( $ii ) ) {
+			$ii = $ii[0];
 
 			$this->title = $ii['canonicaltitle'];
 			$this->rawtitle = $this->wiki->removeNamespace( $this->title );
@@ -274,7 +275,7 @@ class Image {
 
 		$imageInfo = $this->wiki->listHandler( $imageInfoArray );
 		if( count( $imageInfo ) > 0 ) {
-			return $imageInfo[0];
+			return $imageInfo;
 		} else {
 			// Does not exist
 			return false;
@@ -667,7 +668,7 @@ class Image {
 		$ii = $this->imageinfo( 1, $width, $height );
 
 		if( is_array( $ii ) ) {
-			$ii = $ii;
+			$ii = $ii[0];
 
 			if( $width != -1 ) {
 				$url = $ii['thumburl'];


### PR DESCRIPTION
Takes an alternative approach to ce0f1a33 (and my previous edits) which
were sticking plasters over this accidental removal.

Potentially breaking change but was very buggy before.