### PR TITLE
Bugs1

### DIFF
--- a/GenFunctions.php
+++ b/GenFunctions.php
@@ -230,8 +230,10 @@ function cecho( $text, $return = false ) {
 
 	if( !isset( $pgColorizer ) ) $pgColorizer = new lime_colorizer( true );
 
-	$text = preg_replace( '/\[(.+?)\|(\w+)\]/se', '$pgColorizer->colorize("$1", "$2")', $text );
-
+	$text = preg_replace_callback( '/\[(.+?)\|(\w+)\]/s', function ($m) {
+                    global $pgColorizer;
+                    return $pgColorizer->colorize($m[1], $m[2]);
+                }, $text );
 	if( $return ) return $text;
 
 	echo $text;

--- a/Includes/Image.php
+++ b/Includes/Image.php
@@ -197,9 +197,9 @@ class Image {
 					$this->metadata[$metadata['name']] = $metadata['value'];
 				}
 
-			} else {
-				$this->exists = false;
-			}
+        		}
+                } else {
+                        $this->exists = false;
 		}
 
 	}


### PR DESCRIPTION
Switch /e deprecated on preg_replace
Using callback function because switch /e is deprecated

bug : flag 'exists' always false
Moving 'else' code at the right place, so the flag is correctly set