### PR TITLE
Stop version tagging creating an edit summary > 255 chars

### DIFF
--- a/Includes/Page.php
+++ b/Includes/Page.php
@@ -1155,7 +1155,9 @@ class Page {
 
 		$tokens = $this->wiki->get_tokens();
 
-		if( !$pgNotag ) $summary .= $pgTag;
+		if( !$pgNotag ) {
+			$summary = substr( $summary . $pgTag, 0, 255 );
+		}
 
 		if( $tokens['edit'] == '' ) {
 			pecho( "User is not allowed to edit {$this->title}\n\n", PECHO_FATAL );


### PR DESCRIPTION
Edit summaries > 255 chars cause edits to fail.