### PR TITLE
Remove obsolete and to-be-deprecated __autoload function

### DIFF
--- a/Includes/Autoloader.php
+++ b/Includes/Autoloader.php
@@ -88,12 +88,4 @@ class AutoLoader
     }
 }
 
-if( function_exists( 'spl_autoload_register' ) ) {
-    spl_autoload_register(array('AutoLoader', 'autoload'));
-} else {
-    function __autoload($class) {
-        AutoLoader::autoload($class);
-    }
-
-    ini_set('unserialize_callback_func', '__autoload');
-}
+spl_autoload_register(array('AutoLoader', 'autoload'));


### PR DESCRIPTION
[`spl_autoload_register`](http://php.net/manual/en/function.spl-autoload-register.php) exists since PHP 5.1.2 (11 years old),
and [`__autoload`](http://php.net/manual/en/function.autoload.php) will be deprecated in PHP 7.2.